### PR TITLE
Update README.md from install-ra to xtask

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need `ra_lsp_server` installed. You can build it from source:
 git clone https://github.com/rust-analyzer/rust-analyzer && cd rust-analyzer
 
 rustup component add rust-src
-cargo install-ra --server
+cargo xtask install --server
 ```
 
 ## Configurations


### PR DESCRIPTION
https://github.com/rust-analyzer/rust-analyzer updated their installation instructions to:
```
# clone the repo
$ git clone https://github.com/rust-analyzer/rust-analyzer && cd rust-analyzer

# install both the language server and VS Code extension
$ cargo xtask install

# alternatively, install only the server. Binary name is `ra_lsp_server`.
$ cargo xtask install --server
```