### PR TITLE
Enable nightly channel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,19 @@
           ],
           "default": "off",
           "description": "Trace requests to the rust-analyzer"
+        },
+        "rust-analyzer.updates.channel": {
+          "type": "string",
+          "default": "stable",
+          "enum": [
+            "stable",
+            "nightly"
+          ],
+          "description": "Choose `\"nightly\"` updates to get the latest features and bug fixes every day. While `\"stable\"` releases occur weekly and don't contain cutting-edge features from VSCode proposed APIs",
+          "enumDescriptions": [
+            "`\"stable\"` updates are shipped weekly, they don't contain cutting-edge features from VSCode proposed APIs but have less bugs in general",
+            "`\"nightly\"` updates are shipped daily (extension updates automatically by downloading artifacts directly from GitHub), they contain cutting-edge features and latest bug fixes. These releases help us get your feedback very quickly and speed up rust-analyzer development **drastically**"
+          ]
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,9 +14,11 @@ export interface CargoFeatures {
   loadOutDirsFromCheck: boolean;
 }
 
+export type UpdatesChannel = 'stable' | 'nightly';
+
 export class Config {
   private static readonly rootSection = 'rust-analyzer';
-  private static readonly requiresReloadOpts = ['serverPath', 'cargo', 'files'].map((opt) => `${Config.rootSection}.${opt}`);
+  private static readonly requiresReloadOpts = ['serverPath', 'cargo', 'files', 'updates'].map((opt) => `${Config.rootSection}.${opt}`);
   private cfg: WorkspaceConfiguration;
 
   constructor() {
@@ -46,5 +48,9 @@ export class Config {
     return {
       command: this.cfg.get<string>('checkOnSave.command')!,
     };
+  }
+
+  get channel() {
+    return this.cfg.get<UpdatesChannel>('updates.channel')!;
   }
 }

--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -97,7 +97,7 @@ export class Ctx {
       return;
     }
 
-    const latest = await getLatestRelease();
+    const latest = await getLatestRelease(this.config.channel);
     if (!latest) {
       return;
     }
@@ -115,7 +115,7 @@ export class Ctx {
     if (ret === 0) {
       await this.stopServer();
       try {
-        await downloadServer(this.extCtx);
+        await downloadServer(this.extCtx, this.config.channel);
       } catch (e) {
         workspace.showMessage(`Upgrade rust-analyzer failed, please try again`, 'error');
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import { ExtensionContext, workspace } from 'coc.nvim';
 import { existsSync, mkdirSync } from 'fs';
 import * as cmds from './cmds';
 import { Ctx } from './ctx';
+import { Config } from './config';
 import { downloadServer } from './downloader';
 import { activateStatusDisplay } from './status_display';
 
 export async function activate(context: ExtensionContext): Promise<void> {
   const ctx = new Ctx(context);
+  const config = new Config();
 
   const serverRoot = context.storagePath;
   if (!existsSync(serverRoot)) {
@@ -19,7 +21,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     const ret = await workspace.showQuickpick(['Yes', 'Cancel'], msg);
     if (ret === 0) {
       try {
-        await downloadServer(context);
+        await downloadServer(context, config.channel);
       } catch (e) {
         msg = 'Download rust-analyzer failed, you can get it from https://github.com/rust-analyzer/rust-analyzer';
         workspace.showMessage(msg, 'error');


### PR DESCRIPTION
Similar to the VS Code plugin, the `rust-analyzer.updates.channel` setting downloads nightly releases if set to `nightly`

Config name and documentation taken from `rust-analyzer`: https://github.com/rust-analyzer/rust-analyzer/blob/master/editors/code/package.json#L342