### PR TITLE
Add debugSingle command - This enables codelens debug action

### DIFF
--- a/package.json
+++ b/package.json
@@ -482,6 +482,11 @@
         "category": "Rust Analyzer"
       },
       {
+        "command": "rust-analyzer.debugSingle",
+        "title": "Run Single",
+        "category": "Rust Analyzer"
+      },
+      {
         "command": "rust-analyzer.runSingle",
         "title": "Run Single",
         "category": "Rust Analyzer"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from 'child_process';
+import { spawnSync, spawn } from 'child_process';
+import readline from 'readline';
 import { commands, Terminal, TerminalOptions, Uri, workspace } from 'coc.nvim';
 import { Location, Position, Range, TextDocumentEdit, TextDocumentPositionParams, TextEdit, WorkspaceEdit } from 'vscode-languageserver-protocol';
 import { Cmd, Ctx, isRustDocument } from './ctx';
@@ -190,6 +191,88 @@ export function run(ctx: Ctx): Cmd {
       t.sendText(cmd);
     });
   };
+}
+
+export function debugSingle(): Cmd {
+    return async (runnable: ra.Runnable) => {
+        const {document} = await workspace.getCurrentState();
+        if (!runnable || !isRustDocument(document)) return;
+
+        const args = [...runnable.args.cargoArgs];
+        if (runnable.args.cargoExtraArgs.length > 0) {
+            args.push(...runnable.args.cargoExtraArgs);
+        }
+
+        // do not run tests, we will run through gdb
+        if (args[0] === "test") {
+            args.push("--no-run");
+        }
+
+        // output as json
+        args.push("--message-format=json");
+        // remove noise
+        args.push("-q");
+
+        if (runnable.args.executableArgs.length > 0) {
+            args.push('--', ...runnable.args.executableArgs);
+        }
+
+        if (args[0] === "run") {
+            args[0] = "build";
+        }
+
+        console.debug(`${runnable.kind} ${args}`);
+
+        const proc = spawn(runnable.kind, args, {shell: true});
+
+        const rl = readline.createInterface({
+            input: proc.stdout,
+            crlfDelay: Infinity
+        });
+
+        let executable = null;
+        for await (const line of rl) {
+            if (!line) {
+                continue;
+            }
+
+            let cargoMessage = {};
+            try {
+                cargoMessage = JSON.parse(line);
+            } catch (e) {
+                console.error(e);
+                continue;
+            }
+
+            if (!cargoMessage) {
+                console.debug(`Skipping cargo message: ${cargoMessage}`);
+            }
+
+            if (cargoMessage["reason"] !== "compiler-artifact") {
+                console.debug(`Not artifact: ${cargoMessage["reason"]}`);
+                continue;
+            }
+
+            const target = cargoMessage["target"] || {};
+            const targetKind = target["kind"] || [];
+            if (!targetKind.includes("bin")) {
+                console.debug(`Not bin: ${targetKind}`);
+                continue;
+            }
+
+            executable = cargoMessage["executable"];
+        }
+
+        if (!executable) {
+            throw new Error("Could not find executable");
+        }
+
+        const executableArgs = runnable.args.executableArgs.join(" ");
+
+        console.info(`Debugging executable: ${executable} ${executableArgs}`);
+
+        await workspace.nvim.command(`TermdebugCommand ${executable} ${executableArgs}`);
+    };
 }
 
 export function runSingle(): Cmd {


### PR DESCRIPTION
Hi you folks have been doing awesome work with coc-rust-analyzer!

This pr enables the debug codelens action using the termdebug package from neovim.

I'm not very familiar with coc, so please let me know where the code can be improved and I will happily work on it.

This requires termdebug package:

```viml
packadd termdebug
let g:termdebugger="rust-gdb"
```

Btw this is heavily based on rust-analyzer for vscode.