### PR TITLE
Add option to auto update rust-analyzer bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This extension is configured using a jsonc file. You can open this configuration
 
 - `rust-analyzer.serverPath`: Path to custom `rust-analyzer` executable, default: `''`
 - `rust-analyzer.updates.channel`: Use `stable` or `nightly` updates, default: `stable`
+- `rust-analyzer.updates.auto`: Boolean. Auto update rust-analyzer bin if it's not found. If true, this will not prompt during start. Default: false
 - `rust-analyzer.diagnostics.enable`: Whether to show native rust-analyzer diagnostics, default: `true`
 - `rust-analyzer.diagnostics.enableExperimental`: Whether to show experimental rust-analyzer diagnostics that might have more false positives than usual, default: `true`
 - `rust-analyzer.diagnostics.disabled`: List of rust-analyzer diagnostics to disable, default: `[]`

--- a/package.json
+++ b/package.json
@@ -432,6 +432,11 @@
             "`\"nightly\"` updates are shipped daily (extension updates automatically by downloading artifacts directly from GitHub), they contain cutting-edge features and latest bug fixes. These releases help us get your feedback very quickly and speed up rust-analyzer development **drastically**"
           ]
         },
+        "rust-analyzer.updates.auto": {
+            "type": "boolean",
+            "default": false,
+            "description": "Automatically update the server binary if it has not been resolved in path. This does not prompt for downloading the binary."
+        },
         "rust-analyzer.debug.runtime": {
           "type": "string",
           "default": "termdebug",

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,10 @@ export class Config {
     return this.cfg.get<UpdatesChannel>('updates.channel')!;
   }
 
+  get autoUpdate() {
+    return this.cfg.get<boolean>('updates.auto')!;
+  }
+
   get cargo() {
     return {
       autoreload: this.cfg.get<boolean>('cargo.autoreload'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   const bin = ctx.resolveBin();
   if (!bin) {
+    const shouldPrompt = !config.autoUpdate;
+
+    let ret = 0;
     let msg = 'Rust Analyzer is not found, download from GitHub release?';
-    const ret = await workspace.showQuickpick(['Yes', 'Cancel'], msg);
+    if (shouldPrompt) {
+      ret = await workspace.showQuickpick(['Yes', 'Cancel'], msg);
+    }
+
     if (ret === 0) {
       try {
         await downloadServer(context, config.channel);


### PR DESCRIPTION
Useful when running headless nvim. The prompt blocks the start up