### PR TITLE
feat: Add `rust-analyzer.explainError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can use these commands by `:CocCommand XYZ`.
 - `rust-analyzer.ssr`: Structural Search Replace
 - `rust-analyzer.serverVersion`: Show current Rust Analyzer server version
 - `rust-analyzer.toggleInlayHints`: Toggle inlay hints on/off
+- `rust-analyzer.explainError`: Explain the currently hovered error message
 - `rust-analyzer.upgrade`: Download latest `rust-analyzer` from [GitHub release](https://github.com/rust-analyzer/rust-analyzer/releases)
 
 ## Highlight Group

--- a/package.json
+++ b/package.json
@@ -560,6 +560,11 @@
         "command": "rust-analyzer.expandMacro",
         "title": "Expand macro recursively",
         "category": "Rust Analyzer"
+      },
+      {
+        "command": "rust-analyzer.explainError",
+        "title": "Explain the currently hovered diagnostic",
+        "category": "Rust Analyzer"
       }
     ]
   }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import { spawnSync, spawn } from 'child_process';
 import readline from 'readline';
-import { commands, Terminal, TerminalOptions, Uri, workspace } from 'coc.nvim';
+import { commands, Documentation, FloatFactory, Terminal, TerminalOptions, Uri, workspace } from 'coc.nvim';
 import { Location, Position, Range, TextDocumentEdit, TextDocumentPositionParams, TextEdit, WorkspaceEdit } from 'vscode-languageserver-protocol';
 import { Cmd, Ctx, isRustDocument } from './ctx';
 import * as ra from './lsp_ext';
@@ -11,6 +11,12 @@ class RunnableQuickPick {
   constructor(public runnable: ra.Runnable) {
     this.label = runnable.label;
   }
+}
+
+function isInRange(range: Range, position: Position): boolean {
+  const lineWithin = range.start.line <= position.line && range.end.line >= position.line;
+  const charWithin = range.start.character <= position.character && range.end.line >= position.character;
+  return lineWithin && charWithin;
 }
 
 function codeFormat(expanded: ra.ExpandedMacro): string {
@@ -349,6 +355,29 @@ export function expandMacro(ctx: Ctx): Cmd {
       const buf = await workspace.nvim.buffer;
       buf.setLines(codeFormat(expanded).split('\n'), { start: 0, end: -1 });
     });
+  };
+}
+
+export function explainError(ctx: Ctx): Cmd {
+  return async () => {
+    const { document, position } = await workspace.getCurrentState();
+    if (!isRustDocument(document)) return;
+
+    const diagnostic = ctx.client.diagnostics?.get(workspace.uri)?.find((diagnostic) => isInRange(diagnostic.range, position));
+
+    if (diagnostic?.code) {
+      const explaination = spawnSync('rustc', ['--explain', `${diagnostic.code}`], { encoding: 'utf-8' }).stdout;
+
+      const docs: Documentation[] = [];
+      let isCode = false;
+      for (const part of explaination.split('```\n')) {
+        docs.push({ content: part, filetype: isCode ? 'rust' : 'markdown' });
+        isCode = !isCode;
+      }
+
+      const factory: FloatFactory = new FloatFactory(workspace.nvim, workspace.env);
+      await factory.create(docs);
+    }
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   ctx.registerCommand('runSingle', cmds.runSingle);
   ctx.registerCommand('syntaxTree', cmds.syntaxTree);
   ctx.registerCommand('showReferences', cmds.showReferences);
+  ctx.registerCommand('explainError', cmds.explainError);
   ctx.registerCommand('upgrade', cmds.upgrade);
   ctx.registerCommand('ssr', cmds.ssr);
   ctx.registerCommand('serverVersion', cmds.serverVersion);


### PR DESCRIPTION
This PR adds `rust-analyzer.explainError` as discussed in #467, which shows the output of `rustc --explain`, explaining the currently hovered error. It can both show it in a popup, as well as in a new buffer. This is configurable via `rust-analyzer.explainInPopup`.

Here's an example showing how it looks in the popup:
![image](https://user-images.githubusercontent.com/5300871/99305319-e7b92800-2853-11eb-8db3-79eba2ec1de2.png)

This is how it looks with `rust-analyzer.explainInPopup` set to false
![image](https://user-images.githubusercontent.com/5300871/99305476-20f19800-2854-11eb-956f-0b4a4068c781.png)


