### PR TITLE
Added logic to display symbol name together with its type

### DIFF
--- a/src/inlay_hints.ts
+++ b/src/inlay_hints.ts
@@ -124,6 +124,8 @@ export class HintsUpdater implements Disposable {
           continue;
       }
     }
+    console.info(JSON.stringify(decorations));
+    console.info(doc);
 
     doc.buffer.clearNamespace(this.inlayHintsNS);
     const chaining_hints = {};
@@ -131,7 +133,11 @@ export class HintsUpdater implements Disposable {
     if (this.ctx.config.inlayHints.typeHints) {
       const sep = this.ctx.config.inlayHints.typeHintsSeparator;
       for (const item of decorations.type) {
-        const chunks: [[string, string]] = [[`${sep}${item.label}`, 'CocRustTypeHint']];
+        let sn_start = item.range.start.character;
+        let sn_end = item.range.end.character;
+        let line = doc.getline(item.range.start.line);
+        let symbol_name = line.substring(sn_start, sn_end);
+        const chunks: [[string, string]] = [[`${sep}${symbol_name}: ${item.label}`, 'CocRustTypeHint']];
         if (chaining_hints[item.range.end.line] === undefined) {
           chaining_hints[item.range.end.line] = chunks;
         } else {
@@ -144,7 +150,7 @@ export class HintsUpdater implements Disposable {
     if (this.ctx.config.inlayHints.chainingHints) {
       const sep = this.ctx.config.inlayHints.chainingHintsSeparator;
       for (const item of decorations.chaining) {
-        const chunks: [[string, string]] = [[`${sep}${item.label}`, 'CocRustChainingHint']];
+        const chunks: [[string, string]] = [[`${sep} ${item.label}`, 'CocRustChainingHint']];
         if (chaining_hints[item.range.end.line] === undefined) {
           chaining_hints[item.range.end.line] = chunks;
         } else {

--- a/src/inlay_hints.ts
+++ b/src/inlay_hints.ts
@@ -124,8 +124,6 @@ export class HintsUpdater implements Disposable {
           continue;
       }
     }
-    console.info(JSON.stringify(decorations));
-    console.info(doc);
 
     doc.buffer.clearNamespace(this.inlayHintsNS);
     const chaining_hints = {};

--- a/src/inlay_hints.ts
+++ b/src/inlay_hints.ts
@@ -133,10 +133,10 @@ export class HintsUpdater implements Disposable {
     if (this.ctx.config.inlayHints.typeHints) {
       const sep = this.ctx.config.inlayHints.typeHintsSeparator;
       for (const item of decorations.type) {
-        let sn_start = item.range.start.character;
-        let sn_end = item.range.end.character;
-        let line = doc.getline(item.range.start.line);
-        let symbol_name = line.substring(sn_start, sn_end);
+        const sn_start = item.range.start.character;
+        const sn_end = item.range.end.character;
+        const line = doc.getline(item.range.start.line);
+        const symbol_name = line.substring(sn_start, sn_end);
         const chunks: [[string, string]] = [[`${sep}${symbol_name}: ${item.label}`, 'CocRustTypeHint']];
         if (chaining_hints[item.range.end.line] === undefined) {
           chaining_hints[item.range.end.line] = chunks;

--- a/src/inlay_hints.ts
+++ b/src/inlay_hints.ts
@@ -148,7 +148,7 @@ export class HintsUpdater implements Disposable {
     if (this.ctx.config.inlayHints.chainingHints) {
       const sep = this.ctx.config.inlayHints.chainingHintsSeparator;
       for (const item of decorations.chaining) {
-        const chunks: [[string, string]] = [[`${sep} ${item.label}`, 'CocRustChainingHint']];
+        const chunks: [[string, string]] = [[`${sep}${item.label}`, 'CocRustChainingHint']];
         if (chaining_hints[item.range.end.line] === undefined) {
           chaining_hints[item.range.end.line] = chunks;
         } else {


### PR DESCRIPTION
#394 

I made a small change to @the10thWiz's patch to also add the name of the symbol together with the type. The result will look like this:


<img width="679" alt="Screen Shot 2020-12-11 at 12 48 18 PM" src="https://user-images.githubusercontent.com/775171/101936975-3e91f300-3baf-11eb-94f9-1d66c568f444.png">

IMO this makes it easier to associate the type to its symbol without having to go back and forth in the line. Let me know if that works.