### PR TITLE
fix undefined targetUri

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -110,8 +110,8 @@ export function parentModule(ctx: Ctx): Cmd {
 
     const response = await ctx.client.sendRequest(ra.parentModule, param);
     if (response.length > 0) {
-      const uri = response[0].targetUri;
-      const range = response[0].targetRange;
+      const uri = response[0].uri;
+      const range = response[0].range;
 
       workspace.jumpTo(uri, range?.start);
     }


### PR DESCRIPTION
seems coc.nvim handles https://github.com/rust-analyzer/rust-analyzer/blob/master/editors/code/src/commands.ts#L181-L182 directly but the typings are not correct