### PR TITLE
Fix inlayHints.enable option

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -22,7 +22,7 @@ export type Cmd = (...args: any[]) => unknown;
 export class Ctx {
   client!: LanguageClient;
   private statusBar: StatusBarItem;
-  private updater: HintsUpdater;
+  private updater: HintsUpdater | undefined;
   public readonly config = new Config();
 
   constructor(private readonly extCtx: ExtensionContext) {
@@ -30,8 +30,10 @@ export class Ctx {
     this.statusBar.text = 'rust-analyzer';
     this.extCtx.subscriptions.push(this.statusBar);
 
-    this.updater = new HintsUpdater(this);
-    this.extCtx.subscriptions.push(this.updater);
+    if (this.config.inlayHints.enable) {
+      this.updater = new HintsUpdater(this);
+      this.extCtx.subscriptions.push(this.updater);
+    }
   }
 
   registerCommand(name: string, factory: (ctx: Ctx) => Cmd) {
@@ -183,10 +185,10 @@ export class Ctx {
     await workspace.nvim.command('hi default link CocRustChainingHint CocHintSign');
     await workspace.nvim.command('hi default link CocRustTypeHint CocHintSign');
 
-    this.updater.syncAndRenderHints();
+    this.updater?.syncAndRenderHints();
   }
 
   async toggleInlayHints() {
-    await this.updater.toggle();
+    await this.updater?.toggle();
   }
 }


### PR DESCRIPTION
Currently, setting `rust-analyzer.inlayHints.enable` to false will only disables initial activation, not completely disable inlay hints.
