### PR TITLE
Include executable arguments when executing a runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can use these commands by `:CocCommand XYZ`.
 | Command | Description |
 | -- | -- |
 | rust-analyzer.analyzerStatus | Show rust-analyzer status |
+| rust-analyzer.debug | List available runnables of current file and debug the selected one |
 | rust-analyzer.expandMacro | Expand macro recursively |
 | rust-analyzer.explainError | Explain the currently hovered error message |
 | rust-analyzer.joinLines | Join lines |
@@ -90,7 +91,7 @@ You can use these commands by `:CocCommand XYZ`.
 | rust-analyzer.peekTests | Peek related tests |
 | rust-analyzer.reload | Restart rust-analyzer server |
 | rust-analyzer.reloadWorkspace | Reload workspace |
-| rust-analyzer.run | List available runnables of current file |
+| rust-analyzer.run | List available runnables of current file and run the selected one |
 | rust-analyzer.serverVersion | Show current Rust Analyzer server version |
 | rust-analyzer.ssr | Structural Search Replace |
 | rust-analyzer.syntaxTree | Show syntax tree |

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -227,20 +227,16 @@ export function run(ctx: Ctx): Cmd {
     const runnable = await fetchRunnable(ctx);
     if (!runnable) return;
 
-    const cmd = `${runnable.kind} ${runnable.args.cargoArgs.join(' ')}`;
-    const opt: TerminalOptions = {
-      name: runnable.label,
-      cwd: runnable.args.workspaceRoot,
-    };
-    if (terminal) {
-      terminal.dispose();
-      terminal = undefined;
-    }
-    terminal = await workspace.createTerminal(opt);
-    terminal.sendText(cmd);
-    if (ctx.config.terminal.startinsert) {
-      await workspace.nvim.command('startinsert');
-    }
+    await (runSingle(ctx)(runnable));
+  };
+}
+
+export function debug(ctx: Ctx): Cmd {
+  return async () => {
+    const runnable = await fetchRunnable(ctx);
+    if (!runnable) return;
+
+    await (debugSingle(ctx)(runnable))
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // common commands
   ctx.registerCommand('run', cmds.run);
+  ctx.registerCommand('debug', cmds.debug);
   ctx.registerCommand('ssr', cmds.ssr);
   ctx.registerCommand('upgrade', cmds.upgrade);
   ctx.registerCommand('viewHir', cmds.viewHir);


### PR DESCRIPTION
Fixes #719 

Also added a similar `debug` command and refactored them to use `runSingle` and `debugSingle`. I wasn't able to access `debugSingle` because I think codelens only works on neovim. I assume the original `rust-analyzer.run` was intended as a workaround for vanilla vim users so I provided the same functionality for `rust-analyzer.debug`.