### PR TITLE
Add rust-project.json to rootPatterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       {
         "filetype": "rust",
         "patterns": [
-          "Cargo.toml"
+          "Cargo.toml",
+          "rust-project.json"
         ]
       }
     ],


### PR DESCRIPTION
`coc-rust-analyzer` relies on `coc` to find the correct WorkspaceFolder. The location [is based on](https://github.com/neoclide/coc.nvim/wiki/Using-workspaceFolders) the `rootPatterns` provided by the plugin. Add `rust-project.json` to the pattern list.

Fixes: #917