### PR TITLE
Added single quotes around the executable path for Terminal Runnables

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -341,6 +341,7 @@ export function runSingle(ctx: Ctx): Cmd {
       args.push(...runnable.args.cargoExtraArgs);
     }
     if (runnable.args.executableArgs.length > 0) {
+      runnable.args['executableArgs'][0] = `'${runnable.args['executableArgs'][0]}'`;
       args.push('--', ...runnable.args.executableArgs);
     }
     const cmd = `${runnable.kind} ${args.join(' ')}`;


### PR DESCRIPTION
First noticed in:
https://github.com/rust-lang/rust-analyzer/issues/11489

Where I saw that generics prevent a test case from running. It turns out
that the `<` and `>` made my shell I was redirecting to a file (I tested
this in other shells and got the same behavior). As such, I made a PR to
rust-analyzer, but it turns out that this is an "IDE" bug, as we
directly send the cmd to be run on the terminal.

To fix the issue, I simply surrounded the path with quotes.