### PR TITLE
Update users on status of incomplete runnables

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -277,8 +277,6 @@ export function debugSingle(ctx: Ctx): Cmd {
 
     // output as json
     args.push('--message-format=json');
-    // remove noise
-    args.push('-q');
 
     if (runnable.args.executableArgs.length > 0) {
       args.push('--', ...runnable.args.executableArgs);
@@ -291,6 +289,15 @@ export function debugSingle(ctx: Ctx): Cmd {
     console.debug(`${runnable.kind} ${args}`);
 
     const proc = spawn(runnable.kind, args, { shell: true });
+
+    const stderr_rl = readline.createInterface({
+      input: proc.stderr,
+      crlfDelay: Infinity,
+    });
+    stderr_rl.on('line', (line) => {
+      const trimmed_line = line.trimStart();
+      window.showInformationMessage(`Runnable: ${trimmed_line}`);
+    });
 
     const rl = readline.createInterface({
       input: proc.stdout,


### PR DESCRIPTION
When invoking `rust-analyzer.debug` there can be significant delay.
`debugSingle` will try to build the requested target as part of
generating the executable location.

This change notifies the users of these build steps.