### PR TITLE
Show debug runnable build notifications in a window

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -294,9 +294,14 @@ export function debugSingle(ctx: Ctx): Cmd {
       input: proc.stderr,
       crlfDelay: Infinity,
     });
-    stderr_rl.on('line', (line) => {
-      const trimmed_line = line.trimStart();
-      window.showInformationMessage(`Runnable: ${trimmed_line}`);
+    window.withProgress({title: 'Building Debug Target', cancellable: false}, async (progress) => {
+        for await (const line of stderr_rl) {
+            if (!line) {
+                continue;
+            }
+            const message = line.trimStart();
+            progress.report({message: message});
+        }
     });
 
     const rl = readline.createInterface({


### PR DESCRIPTION
Basically #1048 but in the new style:
![Screenshot from 2022-09-07 17-40-02](https://user-images.githubusercontent.com/7339/188921820-18a65362-e16d-4ad5-8813-75dd3115f394.png)
