### PR TITLE
feat: enable localDocs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ class ExperimentalFeatures implements StaticFeature {
     const caps: any = capabilities.experimental ?? {};
     caps.snippetTextEdit = true;
     caps.serverStatusNotification = true;
+    caps.localDocs = true;
     caps.commands = {
       commands: [
         'rust-analyzer.runSingle',


### PR DESCRIPTION
Opening docs (rust-analyzer.openDocs) was broken by commit 1410329b4625f3b6b02bb96675ec5313ba0fab25. This commit contains changes preparing for the rust-analyzer "localDocs" feature https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#local-documentation However, this feature is only activated by specifying the "localDocs" capability. This commits does so in src/client.ts.

To actually make use of the local documentation, the src/commands.ts:openDocs function also needs adjustment. I wrote it such that if a local URI is provided and a corresponding file exists, it is opened.
Otherwise, if a web link is provided, this link is opened.

Note that "vscode.open" would open the local URI in the editor instead of the browser.

Whether local documentation exists depends on whether 'cargo doc' has been executed. If it has been executed but not recently, the documentation might be outdated, so it might be reasonable to generate local documentation before trying to open it.
This is not done so far, but could be added.
It might make sense to run 'cargo doc --no-deps'.