### PR TITLE
fix: open local docs if they exist

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -700,7 +700,7 @@ export function openDocs(ctx: Ctx): Cmd {
     if (doclink) {
       if (doclink.local) {
         const exist = existsSync(Uri.parse(doclink.local).fsPath);
-        if (!exist) {
+        if (exist) {
           await nvim.call('coc#ui#open_url', doclink.local);
           return;
         }


### PR DESCRIPTION
Thanks for merging #1261! However, the negation added to the condition of the if statement means that the code only attempts to open local docs if the corresponding file does not exist, which means local docs don't get used.