### PR TITLE
fix: support numeric snippet labels containing '0'

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -591,7 +591,7 @@ export async function applySnippetWorkspaceEdit(edit: WorkspaceEdit) {
 
     for (const indel of change.edits) {
       const { range } = indel;
-      const parsed = indel.newText.replaceAll('\\}', '}').replaceAll(/\$\{[1-9]+:([^\}]+)\}/g, '$1');
+      const parsed = indel.newText.replaceAll('\\}', '}').replaceAll(/\$\{[0-9]+:([^\}]+)\}/g, '$1');
       const index0 = parsed.indexOf('$0');
       if (index0 !== -1) {
         const prefix = parsed.substring(0, index0);


### PR DESCRIPTION
The language server provides snippets containing numbered placeholders of the form `${n:placeholder}`, where `n` is positive integer, and `placeholder` some value to insert when inserting the snippet.

This fix addresses values for `n` which contain the digit `0`, such as `10` and `20`, which previously did not get expanded properly.