### PR TITLE
Preserve rustc diagnostics on textDocument/diagnostic request

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,23 +1,23 @@
 import {
+  DocumentDiagnosticReportKind,
+  LanguageClient,
+  Uri,
+  diagnosticManager,
+  window,
+  workspace,
   type CodeActionKind,
   type Command,
-  diagnosticManager,
-  DocumentDiagnosticReportKind,
   type Executable,
-  LanguageClient,
   type LanguageClientOptions,
   type Position,
   type Range,
-  RelatedFullDocumentDiagnosticReport,
+  type RelatedFullDocumentDiagnosticReport,
   type ServerOptions,
   type StaticFeature,
-  Uri,
-  window,
-  workspace,
 } from 'coc.nvim';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { CodeAction, type CodeActionParams, CodeActionRequest } from 'vscode-languageserver-protocol';
+import { CodeAction, CodeActionRequest, type CodeActionParams } from 'vscode-languageserver-protocol';
 import type { Config } from './config';
 import { isRustDocument } from './ctx';
 import * as ra from './lsp_ext';
@@ -29,7 +29,13 @@ class ExperimentalFeatures implements StaticFeature {
     caps.serverStatusNotification = true;
     caps.localDocs = true;
     caps.commands = {
-      commands: ['rust-analyzer.runSingle', 'rust-analyzer.debugSingle', 'rust-analyzer.showReferences', 'rust-analyzer.gotoLocation', 'editor.action.triggerParameterHints'],
+      commands: [
+        'rust-analyzer.runSingle',
+        'rust-analyzer.debugSingle',
+        'rust-analyzer.showReferences',
+        'rust-analyzer.gotoLocation',
+        'editor.action.triggerParameterHints',
+      ],
     };
     capabilities.experimental = caps;
   }


### PR DESCRIPTION
As in <https://github.com/rust-lang/rust-analyzer/issues/18709>, Rust Analyzer does not report cargo-produced diagnostics on `textDocument/diagnostic` request. Due to the behavior, coc.nvim often resets diagnostics as described in #1276.

Although I think it's Rust Analyzer that should be fixed, I temporary fix the problem by preserving `rustc` diagnostics on the request with `provideDiagnostic()` middleware.

Closes #1276.