### PR TITLE
fix: rename `syntaxTree` to `viewSyntaxTree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can use these commands by `:CocCommand XYZ`.
 | rust-analyzer.run | List available runnables of current file and run the selected one |
 | rust-analyzer.serverVersion | Show current Rust Analyzer server version |
 | rust-analyzer.ssr | Structural Search Replace |
-| rust-analyzer.syntaxTree | Show syntax tree |
+| rust-analyzer.viewSyntaxTree | Show syntax tree |
 | rust-analyzer.testCurrent | Test Current |
 | rust-analyzer.install | Install latest `rust-analyzer` from [GitHub release](https://github.com/rust-lang/rust-analyzer/releases) |
 | rust-analyzer.upgrade | Download latest `rust-analyzer` from [GitHub release](https://github.com/rust-lang/rust-analyzer/releases) |

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -480,7 +480,7 @@ export function runSingle(ctx: Ctx): Cmd {
   };
 }
 
-export function syntaxTree(ctx: Ctx): Cmd {
+export function viewSyntaxTree(ctx: Ctx): Cmd {
   return async () => {
     const doc = await workspace.document;
     if (!isRustDocument(doc.textDocument)) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   ctx.registerCommand('openDocs', cmds.openDocs);
   ctx.registerCommand('joinLines', cmds.joinLines);
   ctx.registerCommand('peekTests', cmds.peekTests);
-  ctx.registerCommand('syntaxTree', cmds.syntaxTree);
+  ctx.registerCommand('viewSyntaxTree', cmds.viewSyntaxTree);
   ctx.registerCommand('moveItemUp', cmds.moveItemUp);
   ctx.registerCommand('testCurrent', cmds.testCurrent);
   ctx.registerCommand('memoryUsage', cmds.memoryUsage);

--- a/src/lsp_ext.ts
+++ b/src/lsp_ext.ts
@@ -49,8 +49,8 @@ export const runFlycheck = new lc.NotificationType<{
   textDocument: lc.TextDocumentIdentifier | null;
 }>("rust-analyzer/runFlycheck");
 export const shuffleCrateGraph = new lc.RequestType0<null, void>("rust-analyzer/shuffleCrateGraph");
-export const syntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>(
-  "rust-analyzer/syntaxTree",
+export const viewSyntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>(
+  "rust-analyzer/viewSyntaxTree",
 );
 export const viewCrateGraph = new lc.RequestType<ViewCrateGraphParams, string, void>(
   "rust-analyzer/viewCrateGraph",


### PR DESCRIPTION
Changed on the rust-analyzer side, this patch reflects that in the extension.