### PR TITLE
Fix: Improve error message for download failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
         await downloadServer(context, latest);
       } catch (e) {
         console.error(e);
-        msg = 'Download rust-analyzer failed, you can get it from https://github.com/rust-analyzer/rust-analyzer';
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        msg = `Download rust-analyzer failed: ${errorMessage}. You can get it from https://github.com/rust-analyzer/rust-analyzer`;
         window.showErrorMessage(msg);
         return;
       }


### PR DESCRIPTION
When downloading rust-analyzer fails, the previous error message displayed to you was generic:
"Download rust-analyzer failed, you can get it from https://github.com/rust-analyzer/rust-analyzer"

This change enhances the error message by including the specific error details from the exception caught during the download process. The new message format is:
"Download rust-analyzer failed: <specific error message>. You can get it from https://github.com/rust-analyzer/rust-analyzer"

This provides you with more actionable information if a download error occurs, helping you diagnose the issue (e.g., network problems, file system permissions).