### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fannheyward/coc-rust-analyzer/security/code-scanning/6](https://github.com/fannheyward/coc-rust-analyzer/security/code-scanning/6)

The best way to address this is to explicitly set the `permissions` key to restrict the GITHUB_TOKEN privileges. The fix is to add `permissions: contents: read` near the top of the workflow, ideally at the root level (before the `jobs` key), to apply to all jobs in the workflow. This restricts the token so that jobs can only read repository contents and cannot write, which satisfies the principle of least privilege for build/test jobs. Only lines at the top of `.github/workflows/ci.yml` need modification; no changes to step logic or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Restrict GITHUB_TOKEN permissions to read-only for repository contents in the CI workflow