### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '0 17 * * 6'
 
+permissions:
+  contents: read
 jobs:
   CodeQL-Build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/fannheyward/coc-rust-analyzer/security/code-scanning/5](https://github.com/fannheyward/coc-rust-analyzer/security/code-scanning/5)

To fix the issue, add an explicit `permissions` block to the workflow to restrict the default permissions granted to the GITHUB_TOKEN. The recommended minimal fix is to set `contents: read`, granting only read permission to repository contents. 

The preferred location is at the workflow root, just below the workflow `name:` and `on:` block but before the `jobs:` key. This ensures all jobs in the workflow inherit the read-only permission unless otherwise specified. 

The change involves inserting a `permissions:` block before line 12, like this:
```
permissions:
  contents: read
```

No other methods, imports, or variable definitions are necessary; just add the YAML block as described.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Restrict GITHUB_TOKEN permissions in the codeql-analysis workflow by adding `permissions: contents: read`