### PR TITLE
fix: missing env opt for run

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -464,6 +464,7 @@ export function runSingle(ctx: Ctx): Cmd {
     const opt: TerminalOptions = {
       name: runnable.label,
       cwd: runnable.args.cwd,
+      env: runnable.args.environment
     };
     if (terminal) {
       terminal.dispose();


### PR DESCRIPTION
Run `rust-analyzer.run` result args:

```json
"args": {
  "environment": {
    "UPDATE_EXPECT": "1",
    "RUSTC_TOOLCHAIN": "/home/lrne/.rustup/toolchains/nightly-aarch64-unknown-linux-gnu"
  },
  "cwd": "/home/lrne/Project/Rust/test_",
  "overrideCargo": null,
  "workspaceRoot": "/home/lrne/Project/Rust/test_",
  "cargoArgs": [
    "run",
    "--package",
    "test_",
    "--bin",
    "test_"
  ],
  "executableArgs": []
}
```

Example code (cursor on `expect!`):

```rust
use expect_test::expect;

fn main() {
    expect![].assert_eq("foo");
}
```

## Summary by Sourcery

Bug Fixes:
- Ensure `runSingle` commands inherit the `environment` configuration from the runnable arguments so tools like `UPDATE_EXPECT` are respected.