### PR TITLE
feat: supports rust-analyzer.viewMemoryLayout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1800,6 +1800,11 @@
         "category": "rust-analyzer"
       },
       {
+        "command": "rust-analyzer.viewMemoryLayout",
+        "title": "View Memory Layout",
+        "category": "rust-analyzer"
+      },
+      {
         "command": "rust-analyzer.rebuildProcMacros",
         "title": "Rebuild proc macros and build scripts",
         "category": "rust-analyzer"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -528,6 +528,43 @@ export function expandMacro(ctx: Ctx): Cmd {
   };
 }
 
+export function viewMemoryLayout(ctx: Ctx): Cmd {
+  return async () => {
+    const { document, position } = await workspace.getCurrentState();
+    if (!isRustDocument(document)) return;
+
+    const param: TextDocumentPositionParams = {
+      textDocument: { uri: document.uri },
+      position,
+    };
+
+    const res = await ctx.client.sendRequest(ra.viewRecursiveMemoryLayout, param);
+    if (!res) return;
+
+    const lines: string[] = [];
+    const process = (idx: number, depth: number) => {
+      const node = res.nodes[idx];
+      lines.push(
+        `${'\t'.repeat(depth)}${node.itemName}: ${node.typename} (size: ${node.size}, align: ${node.alignment}, field offset: ${node.offset})`,
+      );
+      if (node.childrenStart !== -1) {
+        for (let j = node.childrenStart; j < node.childrenStart + node.childrenLen; j++) {
+          process(j, depth + 1);
+        }
+      }
+    };
+    process(0, 0);
+
+    const nvim = workspace.nvim;
+    nvim.pauseNotification();
+    nvim.command('edit +setl\\ buftype=nofile [Layout]', true);
+    nvim.command('setl nobuflisted bufhidden=wipe', true);
+    nvim.call('append', [0, lines], true);
+    nvim.command('exe 1', true);
+    await nvim.resumeNotification(true);
+  };
+}
+
 export function explainError(ctx: Ctx): Cmd {
   return async () => {
     const { document, position } = await workspace.getCurrentState();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -539,7 +539,7 @@ export function viewMemoryLayout(ctx: Ctx): Cmd {
     };
 
     const res = await ctx.client.sendRequest(ra.viewRecursiveMemoryLayout, param);
-    if (!res) return;
+    if (!res || res.nodes.length === 0) return;
 
     const lines: string[] = [];
     const process = (idx: number, depth: number) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   ctx.registerCommand('clearFlycheck', cmds.clearFlycheck);
   ctx.registerCommand('analyzerStatus', cmds.analyzerStatus);
   ctx.registerCommand('viewCrateGraph', cmds.viewCrateGraph);
+  ctx.registerCommand('viewMemoryLayout', cmds.viewMemoryLayout);
   ctx.registerCommand('interpretFunction', cmds.interpretFunction);
   ctx.registerCommand('rebuildProcMacros', cmds.rebuildProcMacros);
   ctx.registerCommand('shuffleCrateGraph', cmds.shuffleCrateGraph);

--- a/src/lsp_ext.ts
+++ b/src/lsp_ext.ts
@@ -294,14 +294,14 @@ export type SsrParams = {
 };
 
 export type RecursiveMemoryLayoutNode = {
-  item_name: string;
+  itemName: string;
   typename: string;
   size: number;
   alignment: number;
   offset: number;
-  parent_idx: number;
-  children_start: number;
-  children_len: number;
+  parentIdx: number;
+  childrenStart: number;
+  childrenLen: number;
 };
 export type RecursiveMemoryLayout = {
   nodes: RecursiveMemoryLayoutNode[];


### PR DESCRIPTION
- **fix: update lsp_ext RecursiveMemoryLayoutNode field names**

  Reference: https://github.com/rust-lang/rust-analyzer/pull/21986

## Summary by Sourcery

Add a command to display Rust memory layouts using rust-analyzer and align the RecursiveMemoryLayout types with the latest LSP extension.

New Features:
- Introduce a rust-analyzer.viewMemoryLayout command that renders the recursive memory layout of the symbol at the current cursor into a scratch buffer.

Bug Fixes:
- Update RecursiveMemoryLayoutNode field names to match the latest rust-analyzer LSP extension schema, preventing mismatches in responses.