### PR TITLE
fix: viewXir uses rust highlight

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -752,6 +752,7 @@ function viewXir(ctx: Ctx, xir: 'HIR' | 'MIR'): Cmd {
     nvim.pauseNotification();
     nvim.command(`edit +setl\\ buftype=nofile [${xir}]`, true);
     nvim.command('setl nobuflisted bufhidden=wipe', true);
+    nvim.command('setl filetype=rust', true);
     nvim.call('append', [0, ret.split('\n')], true);
     nvim.command('exe 1', true);
     await nvim.resumeNotification(true);


### PR DESCRIPTION
Mir and Hir are almost valid rust syntax, highlighting them with rust is reasonable

## Summary by Sourcery

Enhancements:
- Align HIR and MIR buffer display with Rust syntax highlighting to better match their syntax.