### PR TITLE
docs: add Vimspector debugging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,36 @@ You can use these commands by `:CocCommand XYZ`.
 | rust-analyzer.rebuildProcMacros | Rebuild proc macros and build scripts |
 | rust-analyzer.interpretFunction | Interpret Function |
 
+## Debugging with Vimspector
+
+To debug Rust runnables with [Vimspector](https://github.com/puremourning/vimspector), set the debug runtime in `coc-settings.json`:
+
+```jsonc
+{
+  "rust-analyzer.debug.runtime": "vimspector"
+}
+```
+
+Install Vimspector and the CodeLLDB adapter with `:VimspectorInstall CodeLLDB`. Then add a Vimspector configuration, either in the project root as `.vimspector.json` or in a global Vimspector configuration file:
+
+```jsonc
+{
+  "$schema": "https://puremourning.github.io/vimspector/schema/vimspector.schema.json",
+  "configurations": {
+    "launch": {
+      "adapter": "CodeLLDB",
+      "configuration": {
+        "request": "launch",
+        "program": "${Executable}",
+        "args": ["*${Args}"]
+      }
+    }
+  }
+}
+```
+
+The `launch` key must match `rust-analyzer.debug.vimspector.configuration.name`, which defaults to `launch`. `:CocCommand rust-analyzer.debug` passes `Executable` and `Args` to Vimspector for the selected runnable.
+
 ## License
 
 MIT


### PR DESCRIPTION
Fixes #1050

## Summary
- document the `rust-analyzer.debug.runtime` setting for Vimspector
- add a minimal `.vimspector.json` example using `Executable` and `Args`

## Validation
- Not run; documentation-only change prepared via GitHub API without a local checkout.

AI assistance disclosure: This pull request was prepared with the assistance of AI and has not yet been reviewed by a human.

## Summary by Sourcery

Documentation:
- Add a new README section describing how to configure rust-analyzer.debug.runtime for Vimspector and provide a minimal .vimspector.json example for debugging Rust runnables.