### PR TITLE
feat: expose rust-analyzer probe errors

### DIFF
--- a/src/ctx.ts
+++ b/src/ctx.ts
@@ -112,6 +112,9 @@ export class Ctx {
     if (systemBin) {
       const { stderr } = spawnSync(systemBin, ['--version'], { encoding: 'utf8' });
       if (stderr.trim().length > 0) {
+        const errMsg = `Failed to start rust-analyzer: ${stderr.trim()}`;
+        console.error(errMsg);
+        window.showWarningMessage(errMsg);
         return;
       }
 


### PR DESCRIPTION
I ran into this error, and because the extension didn't surface it, it took me quite a while to figure out the cause. At one point, I even thought it was an environment variable issue.

```bash
❯ rust-analyzer --version      
error: Unknown binary 'rust-analyzer' in official toolchain '1.95.0-aarch64-apple-darwin'.
```

## Summary by Sourcery

Bug Fixes:
- Display a warning when rust-analyzer fails to start due to stderr output from the probed binary.